### PR TITLE
fix ADS query script to include older papers

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -12,6 +12,7 @@
   image: "images/bradshaw_bio.png"
   pub_name:
     - "Bradshaw, S. J."
+    - "Bradshaw, S."
     - "Bradshaw, Stephen"
     - "Bradshaw, Stephen J."
   webpage: "http://report.rice.edu/sir/faculty.detail?p=0EC4BA03C8DC0DCB3AB472F0CD2BAB22"

--- a/scripts/fetch_pubs.py
+++ b/scripts/fetch_pubs.py
@@ -17,7 +17,7 @@ ALLOWED_JOURNALS = ['Astronomy and Astrophysics', 'Astronomy & Astrophysics',
                     'The Astrophysical Journal Letters', 'Space Science Reviews', 'Nature']
 ALLOWED_JOURNALS = [aj.strip().lower() for aj in ALLOWED_JOURNALS]
 EARLIEST_YEAR = 1980
-MAX_ROWS = 300 # when testing this script, it might be better set this a bit lower (e.g. 50)
+MAX_ROWS = 300  # when testing this script, it might be better set this a bit lower (e.g. 50)
 MAX_PAGES = 5
 
 


### PR DESCRIPTION
Remove affiliation requirement in script and allow for larger queries so that older papers can be returned. Also set a filter on allowed journals which may need to be adjusted if people publish somewhere weird